### PR TITLE
Remove unneeded install.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -58,15 +58,5 @@
      - libicu-dev
      - libjemalloc1
      - libjemalloc-dev
-- name: Install xenial specific deps
-  when: ansible_distribution_release == 'xenial'
-  apt: name={{ item }} state=latest update_cache=yes
-  with_items:
-     - libgdbm3
-- name: Install bionic specific deps
-  when: ansible_distribution_release == 'bionic'
-  apt: name={{ item }} state=latest update_cache=yes
-  with_items:
-     - libgdbm5
 - name: Add mastodon system user
   user: name=mastodon shell=/bin/bash state=present


### PR DESCRIPTION
I realise libgdbm5 is listed in the official guide, but libgdbm-dev is also listed and will install the correct package (3 or 5) depending upon OS version as a dependency. This also means it can run on e.g. debian servers.