### PR TITLE
Remove unneeded non-mastodon steps.

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,2 +1,0 @@
-- name: restart rsyslog
-  service: name=rsyslog state=restarted

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,20 +1,8 @@
 ---
 # This role installs packages that every Mastodon server needs and does common
 # node setup
-- name: Install python-apt, aptitude, and debconf-utils
-  shell: apt-get update && apt-get -y install python-apt aptitude debconf-utils
-- name: Do any package upgrades
-  apt: upgrade=dist
-- name: Set default locale to en_US.UTF-8
-  debconf: name=locales question='locales/default_environment_locale' value=en_US.UTF-8 vtype='select'
-- name: Generate locales
-  debconf: name=locales question='locales/locales_to_be_generated'  value='en_US.UTF-8 UTF-8' vtype='multiselect'
-- name: Set timezone area
-  debconf: name=tzdata question='tzdata/Areas' value='Etc' vtype='select'
-- name: Set timezone
-  debconf: name=tzdata question='tzdata/Zones/Etc' value='UTC' vtype='select'
-  notify:
-  - restart rsyslog
+- name: Install required ansible things
+  shell: apt-get update && apt-get -y install python-apt apt-transport-https git sudo
 - name: Add Nodesource apt key
   apt_key: url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key" state=present
 - name: Add Nodesource apt repositories


### PR DESCRIPTION
This is more of a questioning PR - I wasn't sure that the playbook should be performing these steps at the start; I have already set up my server with a locale/timezone that I want, and nothing in the installation says it has to be UTC (might have missed something!). I also didn't see why aptitude etc was being installed. But happy to keep these on my fork if there's a reason for this.