### PR TITLE
Make sure LE config is correct for renewals.

### DIFF
--- a/roles/mastodon-nginx/files/cli.ini
+++ b/roles/mastodon-nginx/files/cli.ini
@@ -1,0 +1,2 @@
+authenticator = webroot
+webroot-path = /home/mastodon/live/public/

--- a/roles/mastodon-nginx/tasks/main.yml
+++ b/roles/mastodon-nginx/tasks/main.yml
@@ -24,6 +24,14 @@
     src: letsencrypt-renew.sh
     dest: /etc/cron.daily/letsencrypt-renew.sh
     mode: 0700
+- name: Make Let's Encrypt configuration directory
+  file:
+    dest: /root/.config/letsencrypt
+    state: directory
+- name: Copy Let's Encrypt configuration file
+  copy:
+    src: cli.ini
+    dest: /root/.config/letsencrypt/cli.ini
 - name: Run nginx install tasks
   include_tasks: install.yml
   when: install is defined


### PR DESCRIPTION
I didn't realise LE only used the first run to store the config used for renewals (which will be standalone, not webroot). So set an override config file.